### PR TITLE
capitalize Makefiles

### DIFF
--- a/default/Makefile
+++ b/default/Makefile
@@ -2,7 +2,7 @@
 #### Sample Makefile for building apps with the RIOT OS
 ####
 #### The Sample Filesystem Layout is:
-#### /this makefile
+#### /this Makefile
 #### ../../RIOT 
 #### ../../RIOT/board   for board definitions (if you have one or more)
 #### 
@@ -84,7 +84,7 @@ PROJECT = default
 export BOARD = msb-430h
 
 # mandatory include! 
-include $(RIOTBASE)/makefile.modules 
+include $(RIOTBASE)/Makefile.modules 
 
 # if you want to publish the board into the sources as an uppercase #define
 BB = $(shell echo $(BOARD)|tr 'a-z' 'A-Z')

--- a/default/Makefile.msb430h
+++ b/default/Makefile.msb430h
@@ -2,7 +2,7 @@
 #### Sample Makefile for building apps with the RIOT OS
 ####
 #### The Sample Filesystem Layout is:
-#### /this makefile
+#### /this Makefile
 #### ../../RIOT 
 #### ../../RIOT/board   for board definitions (if you have one or more)
 #### 
@@ -14,21 +14,21 @@ export RIOTBASE =$(CURDIR)/../../RIOT
 export RIOTBOARD =$(RIOTBASE)/board
 
 # the cpu to build for
-export CPU = lpc2387
+export CPU = msp430x16x
+export MCU = msp430x1612
 
 # toolchain config
-export PREFIX = @arm-elf-
+export PREFIX = @msp430-
 export CC = @$(PREFIX)gcc
 export AR = @$(PREFIX)ar
-export CFLAGS = -std=gnu99 -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2
-export ASFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s
+export CFLAGS += -std=gnu99 -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU)
+export ASFLAGS += -mmcu=$(MCU) --defsym $(MCU)=1 --gdwarf-2
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
-FLASH = lpc2k_pgm
 TERM = pyterm.py
-LINKFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)/cpu/$(CPU)/linkerscript.x
+LINKFLAGS = -mmcu=$(MCU) -lgcc $(RIOTBASE)/bin/startup.o
 
 PROJBINDIR = bin
 
@@ -81,14 +81,14 @@ USEMODULE += config
 PROJECT = default
 
 # for easy switching of boards
-export BOARD = msba2
+export BOARD = msb-430h
 
 # mandatory include! 
-include $(RIOTBASE)/makefile.modules 
+include $(RIOTBASE)/Makefile.modules 
 
 # if you want to publish the board into the sources as an uppercase #define
 BB = $(shell echo $(BOARD)|tr 'a-z' 'A-Z')
-CFLAGS += -DBOARD_$(BB)
+CFLAGS += -DBOARD=$(BB)
 export CFLAGS
 
 # your binaries to link

--- a/default/Makefile.msba2
+++ b/default/Makefile.msba2
@@ -2,7 +2,7 @@
 #### Sample Makefile for building apps with the RIOT OS
 ####
 #### The Sample Filesystem Layout is:
-#### /this makefile
+#### /this Makefile
 #### ../../RIOT 
 #### ../../RIOT/board   for board definitions (if you have one or more)
 #### 
@@ -14,21 +14,21 @@ export RIOTBASE =$(CURDIR)/../../RIOT
 export RIOTBOARD =$(RIOTBASE)/board
 
 # the cpu to build for
-export CPU = msp430x16x
-export MCU = msp430x1612
+export CPU = lpc2387
 
 # toolchain config
-export PREFIX = @msp430-
+export PREFIX = @arm-elf-
 export CC = @$(PREFIX)gcc
 export AR = @$(PREFIX)ar
-export CFLAGS += -std=gnu99 -Wstrict-prototypes -gdwarf-2 -Os -Wall -mmcu=$(MCU)
-export ASFLAGS += -mmcu=$(MCU) --defsym $(MCU)=1 --gdwarf-2
+export CFLAGS = -std=gnu99 -O2 -Wall -Wstrict-prototypes -mcpu=arm7tdmi-s -gdwarf-2
+export ASFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s
 export AS = $(PREFIX)as
 export LINK = $(PREFIX)gcc
 export SIZE = $(PREFIX)size
 export OBJCOPY = $(PREFIX)objcopy
+FLASH = lpc2k_pgm
 TERM = pyterm.py
-LINKFLAGS = -mmcu=$(MCU) -lgcc $(RIOTBASE)/bin/startup.o
+LINKFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)/cpu/$(CPU)/linkerscript.x
 
 PROJBINDIR = bin
 
@@ -81,14 +81,14 @@ USEMODULE += config
 PROJECT = default
 
 # for easy switching of boards
-export BOARD = msb-430h
+export BOARD = msba2
 
 # mandatory include! 
-include $(RIOTBASE)/makefile.modules 
+include $(RIOTBASE)/Makefile.modules 
 
 # if you want to publish the board into the sources as an uppercase #define
 BB = $(shell echo $(BOARD)|tr 'a-z' 'A-Z')
-CFLAGS += -DBOARD=$(BB)
+CFLAGS += -DBOARD_$(BB)
 export CFLAGS
 
 # your binaries to link

--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -2,7 +2,7 @@
 #### Sample Makefile for building apps with the RIOT OS
 ####
 #### The Sample Filesystem Layout is:
-#### /this makefile
+#### /this Makefile
 #### ../RIOT 
 #### ../RIOT/board   for board definitions (if you have one or more)
 #### 
@@ -59,7 +59,7 @@ LINKFLAGS = -mmcu=$(MCU) -lgcc $(RIOTBASE)/bin/startup.o
 #USEMODULE += net_mm
 
 # mandatory include! 
-include $(RIOTBASE)/makefile.modules 
+include $(RIOTBASE)/Makefile.modules 
 
 #### Project Config 
 

--- a/hello-world/Makefile.msba2
+++ b/hello-world/Makefile.msba2
@@ -2,7 +2,7 @@
 #### Sample Makefile for building apps with the RIOT OS
 ####
 #### The Sample Filesystem Layout is:
-#### /this makefile
+#### /this Makefile
 #### ../RIOT 
 #### ../RIOT/board   for board definitions (if you have one or more)
 #### 
@@ -58,7 +58,7 @@ LINKFLAGS = -gdwarf-2 -mcpu=arm7tdmi-s -static -lgcc -nostartfiles -T$(RIOTBASE)
 #USEMODULE += net_mm
 
 # mandatory include! 
-include $(RIOTBASE)/makefile.modules 
+include $(RIOTBASE)/Makefile.modules 
 
 #### Project Config 
 

--- a/hello-world/Makefile.msp430h
+++ b/hello-world/Makefile.msp430h
@@ -2,7 +2,7 @@
 #### Sample Makefile for building apps with the RIOT OS
 ####
 #### The Sample Filesystem Layout is:
-#### /this makefile
+#### /this Makefile
 #### ../RIOT 
 #### ../RIOT/board   for board definitions (if you have one or more)
 #### 
@@ -59,7 +59,7 @@ LINKFLAGS = -mmcu=$(MCU) -lgcc $(RIOTBASE)/bin/startup.o
 #USEMODULE += net_mm
 
 # mandatory include! 
-include $(RIOTBASE)/makefile.modules 
+include $(RIOTBASE)/Makefile.modules 
 
 #### Project Config 
 


### PR DESCRIPTION
With commit 5ffe5a9c27e7 renaming Makefiles to be upper case, rename and replace all occurrences of makefile here as well so RIOT Makefiles can be found on a case-sensitive System.
