### PR TITLE
gnu++0x compatibility for RIOT

### DIFF
--- a/default-native/main.c
+++ b/default-native/main.c
@@ -13,6 +13,7 @@
 #include <board.h>
 #include <cc110x_ng.h>
 #include <transceiver.h>
+#include <posix_io.h>
 
 int main(void)
 {


### PR DESCRIPTION
added missing #include <posix_io.h> in the main.c of default-native
