### PR TITLE
add test_vtimer_msg | msba2 crashes when including uart0

### DIFF
--- a/test_vtimer_msg/Makefile
+++ b/test_vtimer_msg/Makefile
@@ -1,0 +1,36 @@
+####
+#### Sample Makefile for building apps with the RIOT OS
+####
+#### The Sample Filesystem Layout is:
+#### /this makefile
+#### ../../RIOT 
+#### ../../boards   for board definitions (if you have one or more)
+#### 
+
+# name of your project
+export PROJECT =$(shell basename $(CURDIR))
+
+# for easy switching of boards
+ifeq ($(strip $(BOARD)),)
+	export BOARD = msba2
+endif
+
+# this has to be the absolute path of the RIOT-base dir
+export RIOTBASE =$(CURDIR)/../../RIOT
+export RIOTCPU =$(CURDIR)/../../RIOT/cpu
+export RIOTBOARD =$(CURDIR)/../../boards
+
+## Modules to include. 
+
+USEMODULE += auto_init
+USEMODULE += vtimer
+# on MSB-A2, it crashes when using these modules
+# on native, it won't compile without them
+ifeq ($(BOARD),native)
+	USEMODULE += uart0
+	USEMODULE += posix
+endif
+
+export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
+
+include $(RIOTBASE)/Makefile.include

--- a/test_vtimer_msg/main.c
+++ b/test_vtimer_msg/main.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+
+#include "vtimer.h"
+#include "thread.h"
+#include "msg.h"
+
+char timer_stack[KERNEL_CONF_STACKSIZE_DEFAULT];
+
+struct timer_msg {
+	vtimer_t timer;
+	timex_t interval;
+	char* msg;
+};
+
+static struct timer_msg msg_a = { .timer = {{0}}, .interval = { .seconds = 2, .microseconds = 0}, .msg = "Hello World" };
+static struct timer_msg msg_b = { .timer = {{0}}, .interval = { .seconds = 5, .microseconds = 0}, .msg = "This is a Test" };
+
+void timer_thread() {
+	printf("This is thread %d\n", thread_getpid());
+
+	while (1) {
+		msg_t m;
+		msg_receive(&m);
+		struct timer_msg* tmsg = (struct timer_msg*) m.content.ptr;
+		printf("every %u.%us: %s\n", tmsg->interval.seconds, tmsg->interval.microseconds, tmsg->msg);
+		if (vtimer_set_msg(&tmsg->timer, tmsg->interval, thread_getpid(), tmsg) != 0)
+			puts("something went wrong");
+	}
+}
+
+int main(void) {
+	msg_t m;
+	int pid = thread_create(timer_stack, sizeof timer_stack, PRIORITY_MAIN-1, CREATE_STACKTEST, timer_thread, "timer");
+
+	puts("sending 1st msg");
+	m.content.ptr = (char*) &msg_a;
+	msg_send(&m, pid, false);
+
+	puts("sending 2nd msg");
+	m.content.ptr = (char*) &msg_b;
+	msg_send(&m, pid, false);
+}


### PR DESCRIPTION
This adds an example for scheduling messages with a vtimer also a demonstration for an issue:
The native build requires the modules uart0 and posix to build.
When compiling for the msba2 these modules are not needed and the board will crash when they are included (there are no warnings in the build). Without them, it works fine.
