### PR TITLE
Renamed sha256 functions to comply with new crypto module

### DIFF
--- a/test_sha256/Makefile
+++ b/test_sha256/Makefile
@@ -18,13 +18,9 @@ endif
 # this has to be the absolute path of the RIOT-base dir
 export RIOTBASE = $(CURDIR)/../../RIOT
 
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
 ## Modules to include.
 
-USEMODULE += crypto
+USEMODULE += crypto_sha256
 
 export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
 

--- a/test_sha256/main.c
+++ b/test_sha256/main.c
@@ -10,16 +10,16 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "sha256.h"
+#include "crypto/sha256.h"
 
 unsigned char hash[SHA256_DIGEST_LENGTH];
 
-void sha256(const char *str, const char *expected)
+void sha256_calc(const char *str, const char *expected)
 {
-    SHA256_CTX sha256;
-    SHA256_Init(&sha256);
-    SHA256_Update(&sha256, str, strlen(str));
-    SHA256_Final(hash, &sha256);
+    sha256_context_t sha256;
+    sha256_init(&sha256);
+    sha256_update(&sha256, str, strlen(str));
+    sha256_final(hash, &sha256);
 
     printf("Input:      %s\n"
            "Expected:   %s\n"
@@ -32,21 +32,21 @@ void sha256(const char *str, const char *expected)
 
 int main(void)
 {
-    sha256("1234567890_1",
+    sha256_calc("1234567890_1",
            "3eda9ffe5537a588f54d0b2a453e5fa932986d0bc0f9556924f5c2379b2c91b0");
-    sha256("1234567890_2",
+    sha256_calc("1234567890_2",
            "a144d0b4d285260ebbbab6840baceaa09eab3e157443c9458de764b7262c8ace");
-    sha256("1234567890_3",
+    sha256_calc("1234567890_3",
            "9f839169d293276d1b799707d2171ac1fd5b78d0f3bc7693dbed831524dd2d77");
-    sha256("1234567890_4",
+    sha256_calc("1234567890_4",
            "6c5fe2a8e3de58a5e5ac061031a8e802ae1fb9e7197862ec1aedf236f0e23475");
-    sha256("0123456789abcde-0123456789abcde-0123456789abcde-0123456789abcde-",
+    sha256_calc("0123456789abcde-0123456789abcde-0123456789abcde-0123456789abcde-",
            "945ab9d52b069923680c2c067fa6092cbbd9234cf7a38628f3033b2d54d3d3bf");
-    sha256("Franz jagt im komplett verwahrlosten Taxi quer durch Bayern",
+    sha256_calc("Franz jagt im komplett verwahrlosten Taxi quer durch Bayern",
            "d32b568cd1b96d459e7291ebf4b25d007f275c9f13149beeb782fac0716613f8");
-    sha256("Frank jagt im komplett verwahrlosten Taxi quer durch Bayern",
+    sha256_calc("Frank jagt im komplett verwahrlosten Taxi quer durch Bayern",
            "78206a866dbb2bf017d8e34274aed01a8ce405b69d45db30bafa00f5eeed7d5e");
-    sha256("",
+    sha256_calc("",
            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
     return 0;

--- a/test_sha256_bytes/Makefile
+++ b/test_sha256_bytes/Makefile
@@ -18,13 +18,8 @@ endif
 # this has to be the absolute path of the RIOT-base dir
 export RIOTBASE = $(CURDIR)/../../RIOT
 
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
 ## Modules to include.
-
-USEMODULE += crypto
+USEMODULE += crypto_sha256
 USEMODULE += random
 
 export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/

--- a/test_sha256_bytes/main.c
+++ b/test_sha256_bytes/main.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #include "hwtimer.h"
-#include "sha256.h"
+#include "crypto/sha256.h"
 
 unsigned char hash[SHA256_DIGEST_LENGTH];
 #define myseed 0x83d385c0 /* random number */
@@ -35,7 +35,7 @@ int main(void)
     unsigned long t1 = hwtimer_now();
     for (int i = 0; i < COUNT; i++) {
         buf_fill((uint32_t *) &buf, (BUF_SIZE / sizeof(uint32_t)));
-        SHA256((uint32_t *) &buf, (BUF_SIZE / sizeof(uint32_t)), &hash);
+        sha256((uint32_t *) &buf, (BUF_SIZE / sizeof(uint32_t)), &hash);
 #if 0
         for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
             printf("%02x", hash[i]);


### PR DESCRIPTION
This PR fixes the test projects for the sha256 hash algorithm to comply with RIOT PR#391. Functionnames for the algorithm are changed to lower case and the USEMODULE string was changed to crypto_sha236.

I further removed the stm32 extensions from the Makefiles as these are (or will be very soon) obsolete and are not working in the current state anyhow...
