### PR TITLE
Makefile modernization

### DIFF
--- a/Makefile.applications_common
+++ b/Makefile.applications_common
@@ -1,3 +1,8 @@
 export BOARD ?= native
 export RIOTBASE ?= $(CURDIR)/../../RIOT/
 export QUIET ?= 1
+
+THIRDPARTYBOARDS = stm32f4discovery agilefox
+ifneq (,$(filter $(BOARD),$(THIRDPARTYBOARDS)))
+	include ../Makefile.thirdparty
+endif

--- a/Makefile.applications_common
+++ b/Makefile.applications_common
@@ -1,0 +1,3 @@
+export BOARD ?= native
+export RIOTBASE ?= $(CURDIR)/../../RIOT/
+export QUIET ?= 1

--- a/Makefile.thirdparty
+++ b/Makefile.thirdparty
@@ -1,0 +1,2 @@
+export RIOTBOARD = $(CURDIR)/../../thirdparty_boards
+export RIOTCPU = $(CURDIR)/../../thirdparty_cpu

--- a/Makefile.unsupported
+++ b/Makefile.unsupported
@@ -1,6 +1,0 @@
-.PHONY: all clean
-
-all:
-	$(error Project $(PROJECT) currently not supported for $(BOARD))
-
-clean: all

--- a/hello-world-blinker/Makefile
+++ b/hello-world-blinker/Makefile
@@ -1,32 +1,11 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = hello-world
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
+include ../Makefile.applications_common
 
 ifeq ($(BOARD),stm32f4discovery)
 	include Makefile.$(BOARD)
 endif
 
-## Modules to include. 
-
 USEMODULE += vtimer
 USEMODULE += auto_init
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
 
 include $(RIOTBASE)/Makefile.include

--- a/hello-world-blinker/Makefile
+++ b/hello-world-blinker/Makefile
@@ -1,6 +1,9 @@
 export PROJECT = hello-world
 include ../Makefile.applications_common
 
+# Boards with RED and GREEN LEDs:
+export BOARD_WHITELIST = msba2 wsn430-v1_3b native wsn430-v1_4 avsextrem
+
 ifeq ($(BOARD),stm32f4discovery)
 	include Makefile.$(BOARD)
 endif

--- a/hello-world-blinker/Makefile
+++ b/hello-world-blinker/Makefile
@@ -4,10 +4,6 @@ include ../Makefile.applications_common
 # Boards with RED and GREEN LEDs:
 export BOARD_WHITELIST = msba2 wsn430-v1_3b native wsn430-v1_4 avsextrem
 
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
 USEMODULE += vtimer
 USEMODULE += auto_init
 

--- a/hello-world-blinker/Makefile.stm32f4discovery
+++ b/hello-world-blinker/Makefile.stm32f4discovery
@@ -1,2 +1,0 @@
-export RIOTBOARD =$(CURDIR)/../../thirdparty_boards
-export RIOTCPU =$(CURDIR)/../../thirdparty_cpu

--- a/hello-world-thread/Makefile
+++ b/hello-world-thread/Makefile
@@ -1,10 +1,6 @@
 export PROJECT = hello-world
 include ../Makefile.applications_common
 
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
 USEMODULE += vtimer
 USEMODULE += auto_init
 

--- a/hello-world-thread/Makefile
+++ b/hello-world-thread/Makefile
@@ -1,39 +1,11 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = hello-world
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
+include ../Makefile.applications_common
 
 ifeq ($(BOARD),stm32f4discovery)
 	include Makefile.$(BOARD)
 endif
 
-## Modules to include. 
-
-#USEMODULE += shell
-#USEMODULE += uart0
-#USEMODULE += posix
 USEMODULE += vtimer
 USEMODULE += auto_init
-#USEMODULE += sht11
-#USEMODULE += ltc4150
-#USEMODULE += cc110x
-#USEMODULE += fat
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
 
 include $(RIOTBASE)/Makefile.include

--- a/hello-world-thread/Makefile.stm32f4discovery
+++ b/hello-world-thread/Makefile.stm32f4discovery
@@ -1,2 +1,0 @@
-export RIOTBOARD =$(CURDIR)/../../thirdparty_boards
-export RIOTCPU =$(CURDIR)/../../thirdparty_cpu

--- a/hello-world-timer/Makefile
+++ b/hello-world-timer/Makefile
@@ -1,6 +1,9 @@
 export PROJECT = hello-world
 include ../Makefile.applications_common
 
+#These boards don't have LED_RED definitions:
+export BOARD_BLACKLIST = chronos pttu mbed_lpc1768 redbee-econotag
+
 ifeq ($(BOARD),stm32f4discovery)
 	include Makefile.$(BOARD)
 endif

--- a/hello-world-timer/Makefile
+++ b/hello-world-timer/Makefile
@@ -4,10 +4,6 @@ include ../Makefile.applications_common
 #These boards don't have LED_RED definitions:
 export BOARD_BLACKLIST = chronos pttu mbed_lpc1768 redbee-econotag
 
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
 USEMODULE += vtimer
 USEMODULE += auto_init
 

--- a/hello-world-timer/Makefile
+++ b/hello-world-timer/Makefile
@@ -1,39 +1,11 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = hello-world
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
+include ../Makefile.applications_common
 
 ifeq ($(BOARD),stm32f4discovery)
 	include Makefile.$(BOARD)
 endif
 
-## Modules to include. 
-
-#USEMODULE += shell
-#USEMODULE += uart0
-#USEMODULE += posix
 USEMODULE += vtimer
 USEMODULE += auto_init
-#USEMODULE += sht11
-#USEMODULE += ltc4150
-#USEMODULE += cc110x
-#USEMODULE += fat
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
 
 include $(RIOTBASE)/Makefile.include

--- a/hello-world-timer/Makefile.stm32f4discovery
+++ b/hello-world-timer/Makefile.stm32f4discovery
@@ -1,2 +1,0 @@
-export RIOTBOARD =$(CURDIR)/../../thirdparty_boards
-export RIOTCPU =$(CURDIR)/../../thirdparty_cpu

--- a/lm75A-temp-sensor-i2c/Makefile
+++ b/lm75A-temp-sensor-i2c/Makefile
@@ -1,42 +1,9 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = lm75A-sensor-i2c
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = msba2
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
-## Modules to include. 
+export BOARD ?= msba2
+include ../Makefile.applications_common
 
 USEMODULE += i2c
 USEMODULE += lm75a
-#USEMODULE += shell
 USEMODULE += gpioint
-#USEMODULE += uart0
-#USEMODULE += posix
-#USEMODULE += vtimer
-#USEMODULE += timex
-#USEMODULE += sht11
-#USEMODULE += ltc4150
-#USEMODULE += cc110x
-#USEMODULE += fat
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/ -I$(RIOTBOARD)/msba2-common/drivers/include
 
 include $(RIOTBASE)/Makefile.include

--- a/lm75A-temp-sensor-i2c/Makefile
+++ b/lm75A-temp-sensor-i2c/Makefile
@@ -2,6 +2,9 @@ export PROJECT = lm75A-sensor-i2c
 export BOARD ?= msba2
 include ../Makefile.applications_common
 
+# These boards have a GREEN LED and i2c:
+export BOARD_WHITELIST = msba2 avsextrem
+
 USEMODULE += i2c
 USEMODULE += lm75a
 USEMODULE += gpioint

--- a/lm75A-temp-sensor-i2c/main.c
+++ b/lm75A-temp-sensor-i2c/main.c
@@ -21,7 +21,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "lpc23xx.h"    /* LPC23xx/24xx definitions */
+
 #include "i2c.h"
 #include "gpioint.h"
 #include "hwtimer.h"
@@ -76,4 +76,3 @@ int main(void)
 
     return EXIT_SUCCESS;
 }
-

--- a/lpc2387-external-interrupts/Makefile
+++ b/lpc2387-external-interrupts/Makefile
@@ -1,39 +1,7 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = external-interrupts
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = msba2
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
-## Modules to include. 
+export BOARD ?= msba2
+include ../Makefile.applications_common
 
 USEMODULE += gpioint
-#USEMODULE += shell
-#USEMODULE += uart0
-#USEMODULE += posix
-#USEMODULE += vtimer
-#USEMODULE += sht11
-#USEMODULE += ltc4150
-#USEMODULE += cc110x
-#USEMODULE += fat
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
 
 include $(RIOTBASE)/Makefile.include

--- a/lpc2387-external-interrupts/Makefile
+++ b/lpc2387-external-interrupts/Makefile
@@ -2,6 +2,9 @@ export PROJECT = external-interrupts
 export BOARD ?= msba2
 include ../Makefile.applications_common
 
+# lpc2387 based boards:
+export BOARD_WHITELIST = msba2 pttu avsextrem
+
 USEMODULE += gpioint
 
 include $(RIOTBASE)/Makefile.include

--- a/pingpong/Makefile
+++ b/pingpong/Makefile
@@ -1,23 +1,3 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../RIOT
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = pingpong
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
-
+include ../Makefile.applications_common
 include $(RIOTBASE)/Makefile.include

--- a/sixlowpan/Makefile
+++ b/sixlowpan/Makefile
@@ -1,32 +1,8 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../RIOT
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = sixlowpan
+include ../Makefile.applications_common
 
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-ifneq (,$(findstring msb-430,$(BOARD)))
-	include $(CURDIR)/../Makefile.unsupported
-else
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
-## Modules to include. 
+# Boards that have cc110x_ng or nativenet support:
+export BOARD_WHITELIST = native msba2 pttu avsextrem
 
 USEMODULE += shell
 USEMODULE += uart0
@@ -44,7 +20,6 @@ else ifeq ($(BOARD),native)
 	USEMODULE += nativenet
 endif
 
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/ -I$(RIOTBASE)/drivers/cc110x_ng/include/ -I$(RIOTBASE)/sys/net/include/
+export INCLUDES += -I$(RIOTBASE)/sys/net/include
 
 include $(RIOTBASE)/Makefile.include
-endif

--- a/srf02-ultrasonic-sensor-i2c/Makefile
+++ b/srf02-ultrasonic-sensor-i2c/Makefile
@@ -1,42 +1,12 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = srf02-ultrasonic-sensor-i2c
+export BOARD ?= msba2
+include ../Makefile.applications_common
 
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = msba2
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
-## Modules to include.
+# These boards have a GREEN LED and i2c:
+export BOARD_WHITELIST = msba2 avsextrem
  
 USEMODULE += i2c
 USEMODULE += srf02
-#USEMODULE += shell
 USEMODULE += gpioint
-#USEMODULE += uart0
-#USEMODULE += posix
-#USEMODULE += timex
-#USEMODULE += vtimer
-#USEMODULE += sht11
-#USEMODULE += ltc4150
-#USEMODULE += cc110x
-#USEMODULE += fat
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/cpu/lpc2387/include/ -I$(RIOTBASE)/drivers/include -I$(RIOTBOARD)/msba2-common/drivers/include
 
 include $(RIOTBASE)/Makefile.include

--- a/srf02-ultrasonic-sensor-i2c/main.c
+++ b/srf02-ultrasonic-sensor-i2c/main.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include "lpc23xx.h"    /* LPC23xx definitions */
+
 #include "i2c.h"
 #include "gpioint.h"
 #include "hwtimer.h"
@@ -55,4 +55,3 @@ int main(void)
     srf02_start_ranging(SRF02_REAL_RANGING_MODE_CM);
     return EXIT_SUCCESS;
 }
-

--- a/srf08-ultrasonic-sensor-i2c/Makefile
+++ b/srf08-ultrasonic-sensor-i2c/Makefile
@@ -1,41 +1,11 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = srf08-ultrasonic-sensor-i2c
+export BOARD ?= msba2
+include ../Makefile.applications_common
 
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = msba2
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
-## Modules to include. 
+# These boards have a GREEN LED and i2c:
+export BOARD_WHITELIST = msba2 avsextrem
 
 USEMODULE += i2c
 USEMODULE += srf08
-#USEMODULE += shell
-#USEMODULE += gpioint
-#USEMODULE += uart0
-#USEMODULE += posix
-#USEMODULE += vtimer
-#USEMODULE += sht11
-#USEMODULE += ltc4150
-#USEMODULE += cc110x
-#USEMODULE += fat
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/ -I$(RIOTBOARD)/msba2-common/drivers/include
 
 include $(RIOTBASE)/Makefile.include

--- a/srf08-ultrasonic-sensor-i2c/main.c
+++ b/srf08-ultrasonic-sensor-i2c/main.c
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include "lpc23xx.h"    /* LPC23xx definitions */
+
 #include "i2c.h"
 #include "gpioint.h"
 #include "hwtimer.h"
@@ -56,4 +56,3 @@ int main(void)
     srf08_start_ranging(SRF08_REAL_RANGING_MODE_CM);
     return EXIT_SUCCESS;
 }
-

--- a/test_at86rf231/Makefile
+++ b/test_at86rf231/Makefile
@@ -1,33 +1,9 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = test_net_if
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = agile_fox
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-QUIET = 1
-
-## Modules to include.
+export BOARD ?= agile_fox
+include ../Makefile.applications_common
 
 USEMODULE += auto_init
 USEMODULE += transceiver
-USEMODULE += ieee802154
 USEMODULE += at86rf231
 
-INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/sys/net/include -I$(RIOTBASE)/drivers/at86rf231/include
-
 include $(RIOTBASE)/Makefile.include
-

--- a/test_at86rf231/Makefile
+++ b/test_at86rf231/Makefile
@@ -1,9 +1,9 @@
 export PROJECT = test_net_if
-export BOARD ?= agile_fox
+export BOARD ?= agilefox
 include ../Makefile.applications_common
 
 # These boards have an at86rf231:
-BOARD_WHITELIST = agile_fox
+BOARD_WHITELIST = agilefox
 
 USEMODULE += auto_init
 USEMODULE += transceiver

--- a/test_at86rf231/Makefile
+++ b/test_at86rf231/Makefile
@@ -2,6 +2,9 @@ export PROJECT = test_net_if
 export BOARD ?= agile_fox
 include ../Makefile.applications_common
 
+# These boards have an at86rf231:
+BOARD_WHITELIST = agile_fox
+
 USEMODULE += auto_init
 USEMODULE += transceiver
 USEMODULE += at86rf231

--- a/test_cc110x_ng/Makefile
+++ b/test_cc110x_ng/Makefile
@@ -1,23 +1,7 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-####
-
-# name of your project
 export PROJECT = test_cc110x_ng
+include ../Makefile.applications_common
 
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = msba2
-endif
-
-ifneq ($(BOARD),msba2)
-	include $(CURDIR)/../Makefile.unsupported
-else
+export BOARD_WHITELIST = msba2
 
 # this has to be the absolute path of the RIOT-base dir
 export RIOTBASE = $(CURDIR)/../../RIOT
@@ -32,7 +16,4 @@ USEMODULE += vtimer
 USEMODULE += cc110x_ng
 USEMODULE += auto_init
 
-export INCLUDES = -I${RIOTBASE}/core/include/ -I${RIOTBASE}/sys/include/ -I${RIOTBASE}/drivers/include/ -I${RIOTBASE}/drivers/cc110x_ng/include/
-
 include $(RIOTBASE)/Makefile.include
-endif

--- a/test_cc2420/Makefile
+++ b/test_cc2420/Makefile
@@ -1,35 +1,11 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = test_net_if
+include ../Makefile.applications_common
 
 BOARD_WHITELIST := telosb wsn430-v1_4 
 BOARD_BLACKLIST :=  
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = telosb
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-QUIET = 1
-
-## Modules to include.
 
 USEMODULE += auto_init
 USEMODULE += transceiver
 USEMODULE += cc2420
 
-INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/drivers/cc2420/include
-
 include $(RIOTBASE)/Makefile.include
-

--- a/test_crypto/Makefile
+++ b/test_crypto/Makefile
@@ -1,22 +1,5 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-####
-
-# name of your project
 export PROJECT = test_crypto
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-    export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE =$(CURDIR)/../../RIOT
+include ../Makefile.applications_common
 
 # list here all modules that are used in your project
 USEMODULE += posix
@@ -31,7 +14,5 @@ USEMODULE += crypto_rc5
 USEMODULE += crypto_skipjack
 USEMODULE += crypto_twofish
 USEMODULE += crypto_sha256
-
-export INCLUDES = -I${RIOTBASE}/core/include/ -I${RIOTBASE}/sys/include/ -I${RIOTBASE}/drivers/include/
 
 include $(RIOTBASE)/Makefile.include

--- a/test_crypto/Makefile
+++ b/test_crypto/Makefile
@@ -1,6 +1,9 @@
 export PROJECT = test_crypto
 include ../Makefile.applications_common
 
+#These boards do not have enough ROM:
+export BOARD_BLACKLIST = wsn430-v1_3b msb-430h chronos msb-430 telosb redbee-econotag wsn430-v1_4
+
 # list here all modules that are used in your project
 USEMODULE += posix
 USEMODULE += uart0

--- a/test_crypto/main.c
+++ b/test_crypto/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
+ * Copyright (C) 2014 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License. See the file LICENSE in the top level directory for more
@@ -17,10 +17,10 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <posix_io.h>
-#include <board_uart0.h>
-#include <shell.h>
-#include <shell_commands.h>
+#include "posix_io.h"
+#include "board_uart0.h"
+#include "shell.h"
+#include "shell_commands.h"
 
 #include "crypto/3des.h"
 #include "crypto/aes.h"
@@ -29,6 +29,7 @@
 #include "crypto/twofish.h"
 #include "crypto/sha256.h"
 
+#define SHELL_BUFSIZE   (UART0_BUFSIZE)
 
 static int shell_readc(void) {
     char c = 0;
@@ -68,9 +69,7 @@ int main(void) {
     printf("twofish:  Preferred block size: %i\n", size);
 
 
-    shell_init(&shell, NULL, shell_readc, shell_putchar);
+    shell_init(&shell, NULL, SHELL_BUFSIZE, shell_readc, shell_putchar);
     shell_run(&shell);
     return 0;
 }
-
-

--- a/test_getpid/Makefile
+++ b/test_getpid/Makefile
@@ -1,34 +1,3 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = test_getpid
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-## Modules to include. 
-
-#USEMODULE += shell
-#USEMODULE += uart0
-#USEMODULE += posix
-#USEMODULE += vtimer
-#USEMODULE += sht11
-#USEMODULE += ltc4150
-#USEMODULE += cc110x
-#USEMODULE += fat
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
-
+include ../Makefile.applications_common
 include $(RIOTBASE)/Makefile.include

--- a/test_ltc4150/Makefile
+++ b/test_ltc4150/Makefile
@@ -1,7 +1,5 @@
 export PROJECT = test_ltc4150
-export BOARD ?= native
-export RIOTBASE ?= $(CURDIR)/../../RIOT
-export QUIET ?= 1
+include ../Makefile.applications_common
 
 export BOARD_WHITELIST = msba2 pttu native avsextrem
 

--- a/test_malloc/Makefile
+++ b/test_malloc/Makefile
@@ -1,38 +1,3 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = test_malloc
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
-## Modules to include. 
-
-#USEMODULE += shell
-#USEMODULE += uart0
-#USEMODULE += posix
-#USEMODULE += vtimer
-#USEMODULE += sht11
-#USEMODULE += ltc4150
-#USEMODULE += cc110x
-#USEMODULE += fat
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
-
+include ../Makefile.applications_common
 include $(RIOTBASE)/Makefile.include

--- a/test_random/Makefile
+++ b/test_random/Makefile
@@ -1,32 +1,6 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = test_random
-
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
-## Modules to include.
+include ../Makefile.applications_common
 
 USEMODULE += random
 
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
-
 include $(RIOTBASE)/Makefile.include
-

--- a/test_random/Makefile
+++ b/test_random/Makefile
@@ -1,6 +1,9 @@
 export PROJECT = test_random
 include ../Makefile.applications_common
 
+# chronos does not have enough RAM:
+export BOARD_BLACKLIST = chronos
+
 USEMODULE += random
 
 include $(RIOTBASE)/Makefile.include

--- a/test_sha256_bytes/Makefile
+++ b/test_sha256_bytes/Makefile
@@ -1,27 +1,7 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = test_sha256_bytes
+include ../Makefile.applications_common
 
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-## Modules to include.
 USEMODULE += crypto_sha256
 USEMODULE += random
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
 
 include $(RIOTBASE)/Makefile.include

--- a/test_sleep/Makefile
+++ b/test_sleep/Makefile
@@ -1,39 +1,6 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../../RIOT 
-#### ../../boards   for board definitions (if you have one or more)
-#### 
-
-# name of your project
 export PROJECT = test_sleep
+include ../Makefile.applications_common
 
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-ifeq ($(BOARD),stm32f4discovery)
-	include Makefile.$(BOARD)
-endif
-
-## Modules to include. 
-
-#USEMODULE += shell
-#USEMODULE += uart0
-#USEMODULE += posix
-#USEMODULE += vtimer
-#USEMODULE += sht11
-#USEMODULE += ltc4150
-#USEMODULE += cc110x
-#USEMODULE += fat
 USEMODULE += ps
-
-export INCLUDES = -I$(RIOTBOARD)/$(BOARD)/include -I$(RIOTBASE)/core/include -I$(RIOTCPU)/$(CPU)/include -I$(RIOTBASE)/sys/lib -I$(RIOTBASE)/sys/include/ -I$(RIOTBASE)/drivers/include/
 
 include $(RIOTBASE)/Makefile.include

--- a/tlayer/Makefile
+++ b/tlayer/Makefile
@@ -1,28 +1,8 @@
-####
-#### Sample Makefile for building apps with the RIOT OS
-####
-#### The Sample Filesystem Layout is:
-#### /this makefile
-#### ../RIOT
-#### ../../boards   for board definitions (if you have one or more)
-####
-
-# name of your project
 export PROJECT = tlayer
 
-# for easy switching of boards
-ifeq ($(strip $(BOARD)),)
-	export BOARD = native
-endif
+include ../Makefile.applications_common
 
-ifneq (,$(findstring msb-430,$(BOARD)))
-	include $(CURDIR)/../Makefile.unsupported
-else
-
-# this has to be the absolute path of the RIOT-base dir
-export RIOTBASE = $(CURDIR)/../../RIOT
-
-## Modules to include. 
+export BOARD_BLACKLIST = msb-430
 
 USEMODULE += auto_init
 USEMODULE += vtimer
@@ -30,12 +10,6 @@ USEMODULE += ps
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += config
-ifeq ($(BOARD),native)
-	USEMODULE += nativenet
-endif
-ifeq ($(BOARD),msba2)
-	USEMODULE += cc110x_ng
-endif
 USEMODULE += transceiver
 USEMODULE += net_help
 USEMODULE += sixlowpan
@@ -45,7 +19,13 @@ USEMODULE += uart0
 USEMODULE += posix
 USEMODULE += ltc4150
 
-export INCLUDES += -I$(RIOTBASE)/sys/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/drivers/cc110x_ng/include -I$(RIOTBASE)/sys/net/include -I$(RIOTBASE)/sys/net/transport_layer/destiny
+ifeq ($(BOARD),native)
+	USEMODULE += nativenet
+endif
+ifeq ($(BOARD),msba2)
+	USEMODULE += cc110x_ng
+endif
+
+export INCLUDES += -I$(RIOTBASE)/sys/net/include -I$(RIOTBASE)/sys/net/transport_layer/destiny
 
 include $(RIOTBASE)/Makefile.include
-endif

--- a/tlayer/Makefile
+++ b/tlayer/Makefile
@@ -2,7 +2,8 @@ export PROJECT = tlayer
 
 include ../Makefile.applications_common
 
-export BOARD_BLACKLIST = msb-430
+# Transceivers are only defined for these boards in this Makefile:
+export BOARD_WHITELIST = msba2 native
 
 USEMODULE += auto_init
 USEMODULE += vtimer


### PR DESCRIPTION
Add a Makefile.applications_common and use it.
Add Makefile.thirdparty and use it.
Add `BOARD_BLACKLIST`s and `BOARD_WHITELIST`s.
Some coding conventions fixes.

test_crypto relies on https://github.com/RIOT-OS/RIOT/pull/824
